### PR TITLE
adds /api/articles/:article_id/comments and refactors /api/articles

### DIFF
--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -79,7 +79,6 @@ describe('GET /api/articles/:article_id', () => {
             expect(body.msg).toBe("Bad Request")
         })
     });
-    // 
 });
 describe('GET /api/articles', () => {
     test('status 200: returns an array of article objects each of which with the following properties: author, title, article_id, topic, created_at, votes, article_img_url, comment_count', () => {
@@ -88,7 +87,8 @@ describe('GET /api/articles', () => {
         .expect(200)
         .then(({body}) => {
             const articles = body.articles
-            expect(articles).toBeSorted({ descensing: true })
+            expect(articles).toHaveLength(13)
+            expect(articles).toBeSorted({ descending: true })
             for(const property in articles){
                 expect(articles[property]).not.toContainKey("body")
                 expect(articles[property]).toMatchObject({
@@ -102,6 +102,45 @@ describe('GET /api/articles', () => {
                     comment_count: expect.any(Number)
                 })
             }
+        })
+    });
+});
+describe('GET /api/articles/:article_id/comments', () => {
+    test('status 200: should return array of comments for the given article_id, each comment with the following properties: comment_id, votes, created_at, author, body, article_id, ordered by date descending', () => {
+        return request(app)
+        .get("/api/articles/9/comments")
+        .expect(200)
+        .then(({body}) => {
+            const comments = body.comments
+            expect(comments).toHaveLength(2)
+            expect(comments).toBeSortedBy('created_at',{descending: true})
+            comments.forEach((comment) => {
+                expect(comment).toMatchObject({
+                    comment_id: expect.any(Number),
+                    votes: expect.any(Number),
+                    created_at: expect.any(String),
+                    author: expect.any(String),
+                    body: expect.any(String),
+                    article_id: expect.any(Number)
+                })
+            })
+        })
+    });
+    test('status 200: should return empty array when given an article_id with no comments', () => {
+        return request(app)
+        .get("/api/articles/2/comments")
+        .expect(200)
+        .then(({body}) => {
+            const comments = body.comments
+            expect(comments).toHaveLength(0)
+        })
+    });
+    test('status 404: should return error message when given an article_id which doesnt exist in the articles table', () => {
+        return request(app)
+        .get("/api/articles/999999999/comments")
+        .expect(404)
+        .then(({body}) => {
+            expect(body.msg).toBe("Article Not Found")
         })
     });
 });

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -103,28 +103,3 @@ describe("formatComments", () => {
     expect(formattedComments[0].created_at).toEqual(new Date(timestamp));
   });
 });
-
-describe("removeBodyProperty", () => {
-  test('should not mutate the input object', () => {
-    const input = {key: "value"}
-    const expected = {key: "value"}
-    removeBodyProperty(input)
-    expect(input).toEqual(expected)
-  });
-  test('should return a new object with a different memory reference', () => {
-    const input = {key: "value"}
-    const returnValue = removeBodyProperty(input)
-    expect(input).not.toBe(returnValue)
-  });
-  test('should take an object and return an object', () => {
-    expect(removeBodyProperty({})).toEqual({})
-  });
-  test('should take an object with a property with key "body" and remove that property', () => {
-    const input = { article_id: 1, body: "info", }
-    const expected = { article_id: 1 }
-    expect(removeBodyProperty(input)).toEqual(expected)
-    const input2 = { body: "info" }
-    const expected2 = {}
-    expect(removeBodyProperty(input2)).toEqual(expected2)
-  });
-})

--- a/app.js
+++ b/app.js
@@ -3,15 +3,16 @@ const app = express();
 const { getTopics } = require("./controllers/topics.controllers.js");
 const { getEndpoints } = require("./controllers/api.controllers.js")
 const { handleServerErrors, handleCustomErrors, handlePsqlErrors } = require("./errors/index.js");
-const { getArticleById, getArticles } = require("./controllers/articles.controllers.js");
-
-app.get("/api/topics", getTopics)
+const { getArticleById, getArticles, getCommentsByArticleId } = require("./controllers/articles.controllers.js");
 
 app.get("/api", getEndpoints)
 
-app.get("/api/articles/:article_id", getArticleById)
+app.get("/api/topics", getTopics)
 
 app.get("/api/articles", getArticles)
+app.get("/api/articles/:article_id", getArticleById)
+app.get("/api/articles/:article_id/comments", getCommentsByArticleId)
+
 
 app.use(handleCustomErrors)
 app.use(handlePsqlErrors)

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -1,4 +1,5 @@
-const { fetchArticleById, fetchArticles } = require("../models/articles.models")
+const { fetchArticleById, fetchArticles, checkArticleExists } = require("../models/articles.models")
+const { fetchCommentsByArticleId } = require("../models/comments.models")
 
 exports.getArticles = (req, res, next) => {
     fetchArticles()
@@ -12,8 +13,17 @@ exports.getArticleById = (req, res, next) => {
     const { article_id } = req.params;
     fetchArticleById(article_id)
         .then((article) => {
-         res.status(200).send({ article })
+            res.status(200).send({ article })
         })
         .catch((err) => next(err))
+}
 
+exports.getCommentsByArticleId = (req, res, next) => {
+    const { article_id } = req.params;
+    Promise.all([checkArticleExists(article_id), fetchCommentsByArticleId(article_id)])
+        .then((promiseResult) =>{
+            const comments = promiseResult[1]
+            res.status(200).send({ comments })
+        })
+        .catch((err) => next(err))
 }

--- a/db/seeds/utils.js
+++ b/db/seeds/utils.js
@@ -20,9 +20,3 @@ exports.formatComments = (comments, idLookup) => {
     };
   });
 };
-
-exports.removeBodyProperty = (articleObj) => {
-  const article = {...articleObj};
-  delete article.body;
-  return article
-}

--- a/endpoints.json
+++ b/endpoints.json
@@ -26,7 +26,7 @@
     }
   },
   "GET /api/articles/:article_id": {
-    "description": "serves a specific article object, with requested article_id",
+    "description": "serves a specific article object with requested article_id",
     "queries": [],
     "exampleResponse": {
      "article": {
@@ -39,6 +39,30 @@
         "votes": 100,
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }
+    }
+  },
+  "GET /api/articles/:article_id/comments": {
+    "description": "serves an array of all comment objects with requested article_id",
+    "queries": [],
+    "exampleResponse": {
+      "comments:": [
+        {
+          "comment_id": 1,
+          "body": "Oh, I've got compassion running out of my nose, pal! I'm the Sultan of Sentiment!",
+          "article_id": 9,
+          "author": "butter_bridge",
+          "votes": 16,
+          "created_at": "2020-04-06T12:17:00.000Z"
+        },
+        {
+          "comment_id": 17,
+          "body": "The owls are not what they seem.",
+          "article_id": 9,
+          "author": "icellusedkars",
+          "votes": 20,
+          "created_at": "2020-03-14T17:02:00.000Z"
+        }
+      ]
     }
   }
 }

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -1,13 +1,9 @@
 const db = require("../db/connection.js")
 
-exports.countComments = (article_id) => {
+exports.fetchCommentsByArticleId = (article_id) => {
     return db
-        .query("SELECT * FROM comments WHERE article_id = $1", [article_id])
+        .query("SELECT * FROM comments WHERE article_id = $1 ORDER BY created_at DESC", [article_id])
         .then(({rows}) => {
-            if(!rows.length){
-                return 0
-            } else {
-                return rows.length
-            }
+            return rows
         })
 }


### PR DESCRIPTION
Hi, here is the code for 06-get-comments-by-article-id and refactors 05-get-article

This includes:
- tests for /api/articles/:article_id/comments
- code within articles and comments MVC to get all comments for requested article_id in correct format back to client
- error handling for /api/articles/:article_id/comments
- updates endpoints.json with /api/articles/:article_id/comments
- refactors previous code: /api/articles MVC and tests - refactors in aggregate function in psql instead of commentCount function (fixes bug caused by promise not resolving completely every time before results are returned)

Thanks