### PR TITLE
adds PATCH /api/articles/:article_id with TDD, MVC and error handling

### DIFF
--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -140,7 +140,15 @@ describe('GET /api/articles/:article_id/comments', () => {
         .get("/api/articles/999999999/comments")
         .expect(404)
         .then(({body}) => {
-            expect(body.msg).toBe("Article Not Found")
+            expect(body.msg).toBe("No article found for article_id: 999999999")
+        })
+    });
+    test('status 400: returns Bad Request when passed an invalid id (not a number)', () => {
+        return request(app)
+        .get("/api/articles/notAnId/comments")
+        .expect(400)
+        .then(({body}) => {
+            expect(body.msg).toBe("Bad Request")
         })
     });
 });
@@ -186,6 +194,102 @@ describe('POST /api/articles/:article_id/comments', () => {
         .expect(404)
         .then(({body}) => {
             expect(body.msg).toBe("Username Not Found")
+        })
+    });
+    test('status 404: returns no article found for article_id when passed an article_id which does not exist', () => {
+        const comment = {
+            username: "lurker",
+            body: "new comment"
+        }
+        return request(app)
+        .post("/api/articles/999999999/comments")
+        .send(comment)
+        .expect(404)
+        .then(({body}) => {
+            expect(body.msg).toBe("No article found for article_id: 999999999")
+        })
+    });
+    test('status 400: returns Bad Request when passed an invalid id (not a number)', () => {
+        const comment = {
+            username: "lurker",
+            body: "new comment"
+        }
+        return request(app)
+        .post("/api/articles/notAnId/comments")
+        .send(comment)
+        .expect(400)
+        .then(({body}) => {
+            expect(body.msg).toBe("Bad Request")
+        })
+    });
+});
+describe('PATCH /api/articles/:article_id', () => {
+    test('status 200: should update an article (given article_id) votes property modified by the inc_votes value provided within the request body, and return the updated article', () => {
+        const newVote = {
+            inc_votes: -20
+        }
+        return request(app)
+        .patch("/api/articles/1")
+        .send(newVote)
+        .expect(200)
+        .then(({body}) => {
+            expect(body.article).toMatchObject({
+                article_id: 1,
+                title: "Living in the shadow of a great man",
+                topic: "mitch",
+                author: "butter_bridge",
+                body: "I find this existence challenging",
+                created_at: "2020-07-09T20:11:00.000Z",
+                votes: 80,
+                article_img_url:
+                "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+            })
+        })
+    });
+    test('status 400: should return Bad Request when given malformed body {}', () => {
+        const newVote = {}
+        return request(app)
+        .patch("/api/articles/1")
+        .send(newVote)
+        .expect(400)
+        .then(({body}) => {
+            expect(body.msg).toBe("Bad Request")
+        })  
+    });
+    test('status 400: should return Bad Request when given body with incorrect data type', () => {
+        const newVote = {
+            inc_votes: "this is not a number"
+        }
+        return request(app)
+        .patch("/api/articles/1")
+        .send(newVote)
+        .expect(400)
+        .then(({body}) => {
+            expect(body.msg).toBe("Bad Request")
+        })  
+    });
+    test('status 404: returns no article found for article_id when passed an article_id which does not exist', () => {
+        const newVote = {
+            inc_votes: -20
+        }
+        return request(app)
+        .patch("/api/articles/999999999")
+        .send(newVote)
+        .expect(404)
+        .then(({body}) => {
+            expect(body.msg).toBe("No article found for article_id: 999999999")
+        })
+    });
+    test('status 400: returns Bad Request when passed an invalid id (not a number)', () => {
+        const newVote = {
+            inc_votes: -20
+        }
+        return request(app)
+        .patch("/api/articles/notAnId")
+        .send(newVote)
+        .expect(400)
+        .then(({body}) => {
+            expect(body.msg).toBe("Bad Request")
         })
     });
 });

--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ const app = express();
 const { getTopics } = require("./controllers/topics.controllers.js");
 const { getEndpoints } = require("./controllers/api.controllers.js")
 const { handleServerErrors, handleCustomErrors, handlePsqlErrors } = require("./errors/index.js");
-const { getArticleById, getArticles, getCommentsByArticleId, postCommentByArticleId } = require("./controllers/articles.controllers.js");
+const { getArticleById, getArticles, getCommentsByArticleId, postCommentByArticleId, patchArticleVotesByArticleId } = require("./controllers/articles.controllers.js");
 
 app.use(express.json())
 
@@ -16,6 +16,8 @@ app.get("/api/articles/:article_id", getArticleById)
 app.get("/api/articles/:article_id/comments", getCommentsByArticleId)
 
 app.post("/api/articles/:article_id/comments", postCommentByArticleId)
+
+app.patch("/api/articles/:article_id", patchArticleVotesByArticleId)
 
 
 app.use(handleCustomErrors)

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -1,4 +1,4 @@
-const { fetchArticleById, fetchArticles, checkArticleExists } = require("../models/articles.models")
+const { fetchArticleById, fetchArticles, updateArticleVotesById } = require("../models/articles.models")
 const { fetchCommentsByArticleId, insertCommentByArticleId } = require("../models/comments.models")
 
 exports.getArticles = (req, res, next) => {
@@ -20,7 +20,7 @@ exports.getArticleById = (req, res, next) => {
 
 exports.getCommentsByArticleId = (req, res, next) => {
     const { article_id } = req.params;
-    Promise.all([checkArticleExists(article_id), fetchCommentsByArticleId(article_id)])
+    Promise.all([fetchArticleById(article_id), fetchCommentsByArticleId(article_id)])
         .then((promiseResult) =>{
             const comments = promiseResult[1]
             res.status(200).send({ comments })
@@ -31,8 +31,21 @@ exports.getCommentsByArticleId = (req, res, next) => {
 exports.postCommentByArticleId = (req, res, next) => {
     const { article_id } = req.params;
     const newComment = req.body;
-    insertCommentByArticleId(article_id, newComment).then((comment) => {
+    Promise.all([fetchArticleById(article_id), insertCommentByArticleId(article_id, newComment)])
+    .then((promiseResult) => {
+        const comment = promiseResult[1]
         res.status(201).send({ comment })
+    })
+    .catch((err) => next(err))
+}
+
+exports.patchArticleVotesByArticleId = (req, res, next) => {
+    const { article_id } = req.params
+    const { inc_votes } = req.body
+    Promise.all([fetchArticleById(article_id), updateArticleVotesById(article_id, inc_votes)])
+    .then((promiseResult) => {
+        const article = promiseResult[1]
+        res.status(200).send({ article })  
     })
     .catch((err) => next(err))
 }

--- a/endpoints.json
+++ b/endpoints.json
@@ -66,7 +66,7 @@
     }
   },
   "POST /api/articles/:article_id/comments": {
-    "description": "serves the newly inserted comment object when provided an object including valid username and body properties",
+    "description": "serves the newly inserted comment object when provided a body with object including valid username and body properties",
     "queries": [],
     "exampleResponse": {
       "comment": {
@@ -76,6 +76,22 @@
         "author": "lurker",
         "votes": 0,
         "created_at": "2024-05-30T08:53:33.319Z"
+      }
+    }
+  },
+  "PATCH /api/articles/:article_id": {
+    "description": "serves the updated article object when provided a body with object including valid inc_votes property",
+    "queries": [],
+    "exampleResponse": {
+      "article": {
+        "article_id": 1,
+        "title": "Living in the shadow of a great man",
+        "topic": "mitch",
+        "author": "butter_bridge",
+        "body": "I find this existence challenging",
+        "created_at": "2020-07-09T20:11:00.000Z",
+        "votes": 80,
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }
     }
   }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,6 +1,4 @@
 const db = require("../db/connection.js")
-const { removeBodyProperty } = require("../db/seeds/utils.js")
-const { countComments } = require("./comments.models.js")
 
 exports.fetchArticles = () => {
     return db
@@ -25,12 +23,14 @@ exports.fetchArticleById = (article_id) => {
         })
 }
 
-exports.checkArticleExists = (article_id) => {
+exports.updateArticleVotesById = (article_id, inc_votes) => {
     return db
-    .query("SELECT * FROM articles WHERE article_id = $1", [article_id])
+    .query("SELECT votes FROM articles WHERE article_id = $1", [article_id])
     .then(({rows}) => {
-        if(!rows.length){
-            return Promise.reject({status: 404, msg: "Article Not Found"})
-        }
+        const oldVotes = rows[0];
+        const newVotes = oldVotes.votes + inc_votes;
+        return db
+            .query("UPDATE articles SET votes = $1 WHERE article_id = $2 RETURNING *", [newVotes, article_id])
+            .then(({rows}) => rows[0])
     })
 }


### PR DESCRIPTION
Hi, here is the code for 08-patch-article-by-article-id

This includes:

- tests for PATCH requests to /api/articles/:article_id/comments
- code within articles and comments MVC to update article votes for requested article_id and send the updated article object in correct format back to client
- error handling for PATCH /api/articles/:article_id/comments
- updates endpoints.json with PATCH /api/articles/:article_id/comments
- refactors 06-get-comments-by-article-id - adds in test for 400 error when article_id is not a number and refactors to use fetchArticleById() instead of extra model checkArticleExists() (and removed this one) to make code DRY
- refactors 07-post-comment-by-article-id - adds tests for 404 and 400 errors when passed invalid article_id (not a number or not a valid article) and updated code to pass these

Thanks