### PR TITLE
adds DELETE /api/comments/:comment_id with TDD, MVC and error handling

### DIFF
--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -173,6 +173,28 @@ describe('POST /api/articles/:article_id/comments', () => {
             })
         })
     });
+    test('status 200: should update an article (given article_id) votes property modified by the inc_votes value provided within the request body, and return the updated article, even if provided with more properties in the request body', () => {
+        const comment = {
+            username: "lurker",
+            body: "new comment",
+            extra_property: "something",
+            another_extra: "something else"
+        }
+        return request(app)
+        .post("/api/articles/9/comments")
+        .send(comment)
+        .expect(201)
+        .then(({body}) => {
+            expect(body.comment).toMatchObject({
+                comment_id: expect.any(Number),
+                votes: 0,
+                created_at: expect.any(String),
+                article_id: 9,
+                author: "lurker",
+                body: "new comment"
+            })
+        })
+    });
     test('status 400: Bad Request when given malformed body {}', () => {
         const comment = {}
         return request(app)
@@ -246,6 +268,30 @@ describe('PATCH /api/articles/:article_id', () => {
             })
         })
     });
+    test('status 200: should update an article (given article_id) votes property modified by the inc_votes value provided within the request body, and return the updated article, even if provided with more properties in the request body', () => {
+        const newVote = {
+            inc_votes: 1,
+            property: "something",
+            another_property: "something else"
+        }
+        return request(app)
+        .patch("/api/articles/1")
+        .send(newVote)
+        .expect(200)
+        .then(({body}) => {
+            expect(body.article).toMatchObject({
+                article_id: 1,
+                title: "Living in the shadow of a great man",
+                topic: "mitch",
+                author: "butter_bridge",
+                body: "I find this existence challenging",
+                created_at: "2020-07-09T20:11:00.000Z",
+                votes: 101,
+                article_img_url:
+                "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+            })
+        })
+    });
     test('status 400: should return Bad Request when given malformed body {}', () => {
         const newVote = {}
         return request(app)
@@ -287,6 +333,29 @@ describe('PATCH /api/articles/:article_id', () => {
         return request(app)
         .patch("/api/articles/notAnId")
         .send(newVote)
+        .expect(400)
+        .then(({body}) => {
+            expect(body.msg).toBe("Bad Request")
+        })
+    });
+});
+describe('DELETE /api/comments/:comment_id', () => {
+    test('status 204: should delete the comment and return no content', () => {
+        return request(app)
+        .delete('/api/comments/1')
+        .expect(204)
+    });
+    test('status 404: should return no comment found for comment_id when passed a comment_id which does not exist', () => {
+        return request(app)
+        .delete('/api/comments/999999999')
+        .expect(404)
+        .then(({body}) => {
+            expect(body.msg).toBe("No comment found for comment id: 999999999")
+        })
+    });
+    test('status 400: returns Bad Request when passed an invalid id (not a number)', () => {
+        return request(app)
+        .delete('/api/comments/notAnId')
         .expect(400)
         .then(({body}) => {
             expect(body.msg).toBe("Bad Request")

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const { getTopics } = require("./controllers/topics.controllers.js");
 const { getEndpoints } = require("./controllers/api.controllers.js")
 const { handleServerErrors, handleCustomErrors, handlePsqlErrors } = require("./errors/index.js");
 const { getArticleById, getArticles, getCommentsByArticleId, postCommentByArticleId, patchArticleVotesByArticleId } = require("./controllers/articles.controllers.js");
+const { deleteCommentById } = require("./controllers/comments.controllers.js");
 
 app.use(express.json())
 
@@ -18,6 +19,8 @@ app.get("/api/articles/:article_id/comments", getCommentsByArticleId)
 app.post("/api/articles/:article_id/comments", postCommentByArticleId)
 
 app.patch("/api/articles/:article_id", patchArticleVotesByArticleId)
+
+app.delete("/api/comments/:comment_id", deleteCommentById)
 
 
 app.use(handleCustomErrors)

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,0 +1,13 @@
+const { removeCommentById, fetchCommentByCommentId } = require("../models/comments.models")
+
+exports.deleteCommentById = (req, res, next) => {
+    const { comment_id } = req.params
+    fetchCommentByCommentId(comment_id)
+    .then(() => {
+        removeCommentById(comment_id)
+    })
+    .then(()=>{
+        res.status(204).send()
+    })
+    .catch((err) => next(err))
+}

--- a/endpoints.json
+++ b/endpoints.json
@@ -42,7 +42,7 @@
     }
   },
   "GET /api/articles/:article_id/comments": {
-    "description": "serves an array of all comment objects with requested article_id",
+    "description": "serves an array of all comment objects for requested article_id",
     "queries": [],
     "exampleResponse": {
       "comments:": [
@@ -66,7 +66,7 @@
     }
   },
   "POST /api/articles/:article_id/comments": {
-    "description": "serves the newly inserted comment object when provided a body with object including valid username and body properties",
+    "description": "serves the newly inserted comment object, for requested article_id, when provided a body with object including valid username and body properties",
     "queries": [],
     "exampleResponse": {
       "comment": {
@@ -80,7 +80,7 @@
     }
   },
   "PATCH /api/articles/:article_id": {
-    "description": "serves the updated article object when provided a body with object including valid inc_votes property",
+    "description": "serves the updated article object, for requested article_id, when provided a body with object including valid inc_votes property",
     "queries": [],
     "exampleResponse": {
       "article": {
@@ -94,5 +94,9 @@
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }
     }
+  },
+  "DELETE /api/comments/:comment_id": {
+    "description": "deletes the comment by given comment id, does not return a response",
+    "queries": []
   }
 }

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -16,3 +16,23 @@ exports.insertCommentByArticleId = (article_id, newComment) => {
             return rows[0]
         })
 }
+
+exports.fetchCommentByCommentId = (comment_id) => {
+    return db
+    .query("SELECT * FROM comments WHERE comment_id = $1", [comment_id])
+    .then(({rows}) => {
+        const comment = rows[0];
+        if(!rows.length){
+            return Promise.reject({
+                status: 404,
+                msg: `No comment found for comment id: ${comment_id}`
+            })
+        }
+        return comment;
+    })
+}
+
+exports.removeCommentById = (comment_id) => {
+    return db
+    .query("DELETE FROM comments WHERE comment_id = $1", [comment_id])
+}


### PR DESCRIPTION
Hi, here is the code for 09-delete-comment-by-id

This includes:

- tests for DELETE requests to /api/comments/:comment_id
- code within comments MVC to delete comment for requested comment_id - which doesn't send data back to the client
- error handling for DELETE requests to /api/comments/:comment_id
- updates endpoints.json with DELETE requests to /api/comments/:comment_id
- refactors 07-post-comment-by-article-id and 08-patch-article-by-article-id: both to include - 200 status when extra properties included in the req.body

Thanks