### PR TITLE
adds /api/articles(topic query) with TDD, MVC and error handling

### DIFF
--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -1,12 +1,15 @@
 const { fetchArticleById, fetchArticles, updateArticleVotesById } = require("../models/articles.models")
 const { fetchCommentsByArticleId, insertCommentByArticleId } = require("../models/comments.models")
+const { fetchTopics } = require("../models/topics.models")
 
 exports.getArticles = (req, res, next) => {
-    fetchArticles()
-        .then((articles) => {
-            res.status(200).send({ articles })
-        })
-        .catch((err) => next(err))
+    const { topic } = req.query
+    Promise.all([fetchTopics(topic), fetchArticles(topic)])
+    .then((promiseResult) => {
+        const articles = promiseResult[1]
+        res.status(200).send({ articles })
+    })
+    .catch((err) => next(err))
 }
 
 exports.getArticleById = (req, res, next) => {

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,11 +1,19 @@
 const db = require("../db/connection.js")
+const { fetchTopics } = require("./topics.models.js")
 
-exports.fetchArticles = () => {
-    return db
-        .query("SELECT articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url, COUNT(comments.comment_id)::INT AS comment_count FROM articles LEFT JOIN comments ON comments.article_id = articles.article_id GROUP BY articles.article_id ORDER BY created_at DESC")
-        .then(({rows}) => {
-            return rows
-        })      
+exports.fetchArticles = (topic) => {
+        let queryStr = `SELECT articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url, COUNT(comments.comment_id)::INT AS comment_count FROM articles LEFT JOIN comments ON comments.article_id = articles.article_id`
+        queryValues = []
+        if(topic){
+            queryStr += ` WHERE articles.topic = $1`
+            queryValues.push(topic)
+        }
+        queryStr += ` GROUP BY articles.article_id ORDER BY created_at DESC`
+        return db
+            .query(queryStr, queryValues)
+            .then(({rows}) => {
+                return rows
+            })      
 }
 
 exports.fetchArticleById = (article_id) => {
@@ -25,12 +33,6 @@ exports.fetchArticleById = (article_id) => {
 
 exports.updateArticleVotesById = (article_id, inc_votes) => {
     return db
-    .query("SELECT votes FROM articles WHERE article_id = $1", [article_id])
-    .then(({rows}) => {
-        const oldVotes = rows[0];
-        const newVotes = oldVotes.votes + inc_votes;
-        return db
-            .query("UPDATE articles SET votes = $1 WHERE article_id = $2 RETURNING *", [newVotes, article_id])
-            .then(({rows}) => rows[0])
-    })
+        .query("UPDATE articles SET votes = votes + $1 WHERE article_id = $2 RETURNING *", [inc_votes, article_id])
+        .then(({rows}) => rows[0])
 }

--- a/models/topics.models.js
+++ b/models/topics.models.js
@@ -1,8 +1,23 @@
 const db = require("../db/connection.js")
 const fs = require("fs/promises")
 
-exports.fetchTopics = () => {
+exports.fetchTopics = (topic) => {
+    let queryStr = `SELECT * FROM topics`;
+    const queryValues = []
+    if(topic){
+        queryStr += ` WHERE slug = $1`
+        queryValues.push(topic)
+    }
     return db
-        .query("SELECT * FROM topics;")
-        .then(({rows}) => rows)
+        .query(queryStr, queryValues)
+        .then(({rows}) => {
+            if(!rows.length){
+                return Promise.reject({ 
+                    status: 404,
+                    msg: `Topic: ${topic} not found`
+                })
+            } else {
+                return rows
+            }
+        })
 }


### PR DESCRIPTION
Hi, here is the code for 11-get-articles-by-topic-query

This includes:

- tests for /api/articles(topic query)
- code within articles and topics MVC to allow /api/articles to take a topic query and send data (filtered by topic) back to the client
- error handling for /api/articles(topic query)
- refactors 08-patch-article-by-article-id - added 200 test for when inc_votes is positive as well as negative / refactored SQL query in updateArticleVotesById to edit votes within one query rather than two.

Thanks