### PR TITLE
adds /api/articles/:article_id(comment_count) feature with TDD, MVC and error handling

### DIFF
--- a/__tests__/integration.test.js
+++ b/__tests__/integration.test.js
@@ -59,7 +59,8 @@ describe('GET /api/articles/:article_id', () => {
                 topic: expect.any(String),
                 created_at: expect.any(String),
                 votes: expect.any(Number),
-                article_img_url: expect.any(String)
+                article_img_url: expect.any(String),
+                comment_count: expect.any(Number)
             })
         })
     });

--- a/endpoints.json
+++ b/endpoints.json
@@ -29,7 +29,7 @@
     "description": "serves a specific article object with requested article_id",
     "queries": [],
     "exampleResponse": {
-     "article": {
+      "article": {
         "article_id": 1,
         "title": "Living in the shadow of a great man",
         "topic": "mitch",
@@ -37,7 +37,8 @@
         "body": "I find this existence challenging",
         "created_at": "2020-07-09T20:11:00.000Z",
         "votes": 100,
-        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        "comment_count": 11
       }
     }
   },

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -18,7 +18,7 @@ exports.fetchArticles = (topic) => {
 
 exports.fetchArticleById = (article_id) => {
     return db
-        .query("SELECT * FROM articles WHERE article_id = $1", [article_id])
+        .query("SELECT articles.*, COUNT(comments.comment_id)::INT AS comment_count FROM articles LEFT JOIN comments ON comments.article_id = articles.article_id WHERE articles.article_id = $1 GROUP BY articles.article_id", [article_id])
         .then(({rows}) => {
             const article = rows[0];
             if(!article){

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
       "dependencies": {
         "dotenv": "^16.0.0",
         "express": "^4.19.2",
-        "pg": "^8.7.3"
+        "pg": "^8.7.3",
+        "pg-format": "^1.0.4"
       },
       "devDependencies": {
         "husky": "^8.0.2",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
         "jest-sorted": "^1.0.15",
-        "pg-format": "^1.0.4",
         "supertest": "^7.0.0"
       }
     },
@@ -3865,7 +3865,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
       "integrity": "sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw==",
-      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -7992,8 +7991,7 @@
     "pg-format": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
-      "integrity": "sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw==",
-      "dev": true
+      "integrity": "sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw=="
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
     "jest-sorted": "^1.0.15",
-    "pg-format": "^1.0.4",
     "supertest": "^7.0.0"
   },
   "dependencies": {
     "dotenv": "^16.0.0",
     "express": "^4.19.2",
-    "pg": "^8.7.3"
+    "pg": "^8.7.3",
+    "pg-format": "^1.0.4"
   },
   "jest": {
     "setupFilesAfterEnv": [


### PR DESCRIPTION
Hi, here is the code for 12-get-article-by-id-comment-count

This includes:

- updates /api/articles/:article_id status 200 test for new comment_count feature
- code within articles MVC to allow/api/articles/:article_id to return a new comment_count as well as original properties back to the client
- refactors package.json to move pg-format into dependencies instead of dev dependencies as required for SQL queries
- updated endpoints.json to update expected response for  /api/articles/:article_id - including new comment_count property

Thanks